### PR TITLE
Build script updates

### DIFF
--- a/Dockerfile-aidreaming
+++ b/Dockerfile-aidreaming
@@ -1,8 +1,11 @@
 # Define base image
 FROM ubuntu:jammy-20230804
 
-# Install needed apt software
-RUN apt-get update && apt-get upgrade -y && apt-get install -y python3 python3-pip python3.10-venv git
+# Install python
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip python3.10-venv git && \
+    apt-get clean
 
 # Create non-root user
 USER root

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-repos_dir=~/repos
+# location for Fooocus repo to be installed to for ease of use
+REPOS_DIR=~/repos
 
-if [ -d "$repos_dir" ]; then
-    cd "$repos_dir"
-else
-    mkdir -p "$repos_dir"
-    cd "$repos_dir"
+# working commit for Fooocus
+FOOOCUS_COMMIT="09e0d1cb3ae5a1d74443009a41da9f96c1b54683"
+
+# make repos dir if it doesn't already exist
+if [ ! -d "$REPOS_DIR" ]; then
+    mkdir -p "$REPOS_DIR"
 fi
 
 if git --version >/dev/null 2>&1; then 
@@ -14,24 +16,31 @@ if git --version >/dev/null 2>&1; then
 else 
     echo "Git is not installed"
     echo "This script will now install git" 
-    sudo apt-get install git
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install git -y
 fi
 
+# clone down Fooocus
+if [ ! -d "$REPOS_DIR/Fooocus" ]; then
+    echo "Fooocus not present. Performing a pull to ensure we've got everything"
+    git clone https://github.com/lllyasviel/Fooocus.git $REPOS_DIR/Fooocus
+else
+    echo "Fooocus already present. Performing a fetch to checkout newer commits as required"
+    git -C $REPOS_DIR/Fooocus fetch --all
+fi
 
-git clone https://github.com/lllyasviel/Fooocus.git
+# Pin Fooocus to known working for everything
+# TODO: silence the detached head state msg ?
+git -C $REPOS_DIR/Fooocus checkout $FOOOCUS_COMMIT
 
 # place Dockerfile and requirements to Fooocus directory and begin building the container state
-cp $(pwd)/Dockerfile-aidreaming $repos_dir/Fooocus/
-cp $(pwd)/requirements_aidreaming.txt $repos_dir/Fooocus/
-
-cd $repos_dir/Fooocus
-
-#Pinning to a known working version
-git checkout 09e0d1cb3ae5a1d74443009a41da9f96c1b54683
+# will always overwrite what is present
+cp $(pwd)/Dockerfile-aidreaming $REPOS_DIR/Fooocus/
+cp $(pwd)/requirements_aidreaming.txt $REPOS_DIR/Fooocus/
 
 echo ""
 echo "If you have already downloaded the models separately You will need to interrupt"
-echo "this build process and place them in the right location within the git repo." 
+echo "this build process and place them in the right location within the git repo."
 sleep 2
 echo "The contents of this script contains the directories for the models."
 sleep 2
@@ -42,33 +51,32 @@ sleep 5
 
 read -p "Do you want to download the models? (Type 'yes' to download now (checks if file exists first), 'exit' to interrupt this process): " confirmation
 if [ "$confirmation" = "yes" ]; then
-    # Downlaoding models only if they are not already downloaded
+    # Downloading models only if they are not already downloaded
     base_model='https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0_0.9vae.safetensors'
-    if [ -f ~/repos/Fooocus/models/checkpoints/sd_xl_base_1.0_0.9vae.safetensors ]; then 
-        echo "Base model already exists"; 
-    else 
+    if [ -f $REPOS_DIR/Fooocus/models/checkpoints/sd_xl_base_1.0_0.9vae.safetensors ]; then
+        echo "Base model already exists"
+    else    
         echo "Base model does not exist."
-        echo "Downloading to ~/repos/Foocus/models/checkpoints"
-        wget -P ~/repos/Fooocus/models/checkpoints $base_model
+        echo "Downloading to $REPOS_DIR/Foocus/models/checkpoints"
+        wget -P $REPOS_DIR/Fooocus/models/checkpoints $base_model
     fi
 
     refiner_model='https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-1.0/resolve/main/sd_xl_refiner_1.0_0.9vae.safetensors'
-    if [ -f ~/repos/Fooocus/models/checkpoints/sd_xl_refiner_1.0_0.9vae.safetensors ]; then 
-        echo "refiner model already exists"; 
-    else 
+    if [ -f $REPOS_DIR/Fooocus/models/checkpoints/sd_xl_refiner_1.0_0.9vae.safetensors ]; then
+        echo "refiner model already exists"
+    else
         echo "refiner model does not exist."
-        echo "Downloading to ~/repos/Foocus/models/checkpoints"
-        wget -P ~/repos/Fooocus/models/checkpoints $refiner_model
+        echo "Downloading to $REPOS_DIR/Foocus/models/checkpoints"
+        wget -P $REPOS_DIR/Fooocus/models/checkpoints $refiner_model
     fi
 
-
     lora_model='https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_offset_example-lora_1.0.safetensors'
-    if [ -f ~/repos/Fooocus/models/loras/sd_xl_offset_example-lora_1.0.safetensors ]; then 
-        echo "Lora model already exists"; 
-    else 
+    if [ -f $REPOS_DIR/Fooocus/models/loras/sd_xl_offset_example-lora_1.0.safetensors ]; then
+        echo "Lora model already exists"
+    else
         echo "Lora model does not exist."
-        echo "Downloading to ~/repos/Foocus/models/loras"
-        wget -P ~/repos/Fooocus/models/loras $lora_model
+        echo "Downloading to $REPOS_DIR/Foocus/models/loras"
+        wget -P $REPOS_DIR/Fooocus/models/loras $lora_model
     fi
 elif [ "$confirmation" = "exit" ]; then
     echo "Process interrupted. Exiting the script."
@@ -78,20 +86,19 @@ else
     sleep 5
 fi
 
-
 # Change the default number of images to generate per prompt to 1
-sed -i "s/image_number = gr.Slider(label='Image Number', minimum=1, maximum=32, step=1, value=2)/image_number = gr.Slider(label='Image Number', minimum=1, maximum=32, step=1, value=1)/" ~/repos/Fooocus/webui.py
+sed -i "s/image_number = gr.Slider(label='Image Number', minimum=1, maximum=32, step=1, value=2)/image_number = gr.Slider(label='Image Number', minimum=1, maximum=32, step=1, value=1)/" $REPOS_DIR/Fooocus/webui.py
 
 # Stop the launch script trying to download models
-sed -i "s/^download_models()/#download_models()/" launch.py
+sed -i "s/^download_models()/#download_models()/" $REPOS_DIR/Fooocus/launch.py
 
 # enable cuda_malloc() function
-sed -i "s/# cuda_malloc()/cuda_malloc()/" launch.py
+sed -i "s/# cuda_malloc()/cuda_malloc()/" $REPOS_DIR/Fooocus/launch.py
 
 # build container
 echo "Building the docker image"
 sleep 1
-sudo docker build -f $repos_dir/Fooocus//Dockerfile-aidreaming -t aidreaming:0.0.1 .
+sudo docker build --pull --no-cache -f $REPOS_DIR/Fooocus/Dockerfile-aidreaming -t aidreaming:0.0.1 $REPOS_DIR/Fooocus
 
 echo ""
 echo "You can now run the container with"
@@ -99,4 +106,3 @@ echo "docker run --gpus all -p 7860:7860 aidreaming:0.0.1"
 echo ""
 echo "This does not work in --detached mode."
 echo "if you want to volume mount the models into  container use -v $(pwd)/localmodel:/app/models/checkpoints"
-


### PR DESCRIPTION
In its current form, there are a handful of issues with the build script. In particular:

- the git repo will try and clone every time, and fail rather than updating an existing installation (ie: what happens when you leave it a couple of months, come back and boom start from scratch rather than respecting what is there)
- there were hard coded references to the repo location rather than using the script variable
- later functionality relied on being in the folder of the script, again mixing up ideas of whether we should be in the folder, or referencing `~/repos/[]`, or using the script variable